### PR TITLE
Fix ModernGLRenderer when not using a window

### DIFF
--- a/moderngl_window/integrations/imgui.py
+++ b/moderngl_window/integrations/imgui.py
@@ -127,7 +127,7 @@ class ModernGLRenderer(BaseOpenGLRenderer):
 
         super().__init__()
 
-        if hasattr(self, "wnd"):
+        if hasattr(self, "wnd") and self.wnd:
             self.resize(*self.wnd.buffer_size)
         elif "display_size" in kwargs:
             self.io.display_size = kwargs.get("display_size")


### PR DESCRIPTION
If just passing a `ctx` and using some external method for window management, `self.wnd` might be none (and the mixin might not be present) and resizing will fail.